### PR TITLE
[BOW-128] Introduce non-default metadata fields

### DIFF
--- a/server/app/shows/[show_id]/page.tsx
+++ b/server/app/shows/[show_id]/page.tsx
@@ -79,7 +79,9 @@ export default async function ShowPage(props: { params: { show_id: string } }) {
   }
   const metaFields = await db.metadataField.findMany({
     where: {
-      target: MetadataTargetType.Show,
+      target: {
+        in: [MetadataTargetType.Show, MetadataTargetType.ShowOrRundown],
+      },
       archived: false,
     },
     orderBy: {

--- a/server/app/shows/[show_id]/rundown/[rundown_id]/page.tsx
+++ b/server/app/shows/[show_id]/rundown/[rundown_id]/page.tsx
@@ -91,7 +91,9 @@ async function RundownMetadata(props: { showID: number; rundownID: number }) {
   const [fields, meta] = await Promise.all([
     db.metadataField.findMany({
       where: {
-        target: MetadataTargetType.Rundown,
+        target: {
+          in: [MetadataTargetType.Rundown, MetadataTargetType.ShowOrRundown],
+        },
         archived: false,
       },
       orderBy: {

--- a/server/package.json
+++ b/server/package.json
@@ -55,6 +55,7 @@
     "server-only": "^0.0.1",
     "superjson": "^1.13.1",
     "tailwind-merge": "^1.14.0",
+    "ts-expect": "^1.3.0",
     "tus-js-client": "^3.1.0",
     "typescript": "5.1.6",
     "undici": "^5.27.2",

--- a/utility/prisma/migrations/20231104211000_add_default_to_metadata_fields/migration.sql
+++ b/utility/prisma/migrations/20231104211000_add_default_to_metadata_fields/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "metadata_fields" ADD COLUMN     "default" BOOLEAN NOT NULL DEFAULT false;

--- a/utility/prisma/migrations/20231104220542_add_metadatatargettype_showorrundown/migration.sql
+++ b/utility/prisma/migrations/20231104220542_add_metadatatargettype_showorrundown/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "MetadataTargetType" ADD VALUE 'ShowOrRundown';

--- a/utility/prisma/schema.prisma
+++ b/utility/prisma/schema.prisma
@@ -126,6 +126,7 @@ model MetadataField {
   type     MetadataValueType
   target   MetadataTargetType
   archived Boolean            @default(false)
+  default  Boolean            @default(false)
 
   values Metadata[]
 

--- a/utility/prisma/schema.prisma
+++ b/utility/prisma/schema.prisma
@@ -112,6 +112,7 @@ model ContinuityItem {
 enum MetadataTargetType {
   Show
   Rundown
+  ShowOrRundown
 }
 
 enum MetadataValueType {

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldCountOrderByAggregateInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldCountOrderByAggregateInputSchema.ts
@@ -10,6 +10,7 @@ export const MetadataFieldCountOrderByAggregateInputSchema: z.ZodType<Prisma.Met
       type: z.lazy(() => SortOrderSchema).optional(),
       target: z.lazy(() => SortOrderSchema).optional(),
       archived: z.lazy(() => SortOrderSchema).optional(),
+      default: z.lazy(() => SortOrderSchema).optional(),
     })
     .strict();
 

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldCreateInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldCreateInputSchema.ts
@@ -11,6 +11,7 @@ export const MetadataFieldCreateInputSchema: z.ZodType<Prisma.MetadataFieldCreat
       type: z.lazy(() => MetadataValueTypeSchema),
       target: z.lazy(() => MetadataTargetTypeSchema),
       archived: z.boolean().optional(),
+      default: z.boolean().optional(),
       values: z
         .lazy(() => MetadataCreateNestedManyWithoutFieldInputSchema)
         .optional(),

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldCreateManyInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldCreateManyInputSchema.ts
@@ -11,6 +11,7 @@ export const MetadataFieldCreateManyInputSchema: z.ZodType<Prisma.MetadataFieldC
       type: z.lazy(() => MetadataValueTypeSchema),
       target: z.lazy(() => MetadataTargetTypeSchema),
       archived: z.boolean().optional(),
+      default: z.boolean().optional(),
     })
     .strict();
 

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldCreateWithoutValuesInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldCreateWithoutValuesInputSchema.ts
@@ -10,6 +10,7 @@ export const MetadataFieldCreateWithoutValuesInputSchema: z.ZodType<Prisma.Metad
       type: z.lazy(() => MetadataValueTypeSchema),
       target: z.lazy(() => MetadataTargetTypeSchema),
       archived: z.boolean().optional(),
+      default: z.boolean().optional(),
     })
     .strict();
 

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldMaxOrderByAggregateInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldMaxOrderByAggregateInputSchema.ts
@@ -10,6 +10,7 @@ export const MetadataFieldMaxOrderByAggregateInputSchema: z.ZodType<Prisma.Metad
       type: z.lazy(() => SortOrderSchema).optional(),
       target: z.lazy(() => SortOrderSchema).optional(),
       archived: z.lazy(() => SortOrderSchema).optional(),
+      default: z.lazy(() => SortOrderSchema).optional(),
     })
     .strict();
 

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldMinOrderByAggregateInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldMinOrderByAggregateInputSchema.ts
@@ -10,6 +10,7 @@ export const MetadataFieldMinOrderByAggregateInputSchema: z.ZodType<Prisma.Metad
       type: z.lazy(() => SortOrderSchema).optional(),
       target: z.lazy(() => SortOrderSchema).optional(),
       archived: z.lazy(() => SortOrderSchema).optional(),
+      default: z.lazy(() => SortOrderSchema).optional(),
     })
     .strict();
 

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldOrderByWithAggregationInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldOrderByWithAggregationInputSchema.ts
@@ -15,6 +15,7 @@ export const MetadataFieldOrderByWithAggregationInputSchema: z.ZodType<Prisma.Me
       type: z.lazy(() => SortOrderSchema).optional(),
       target: z.lazy(() => SortOrderSchema).optional(),
       archived: z.lazy(() => SortOrderSchema).optional(),
+      default: z.lazy(() => SortOrderSchema).optional(),
       _count: z
         .lazy(() => MetadataFieldCountOrderByAggregateInputSchema)
         .optional(),

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldOrderByWithRelationInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldOrderByWithRelationInputSchema.ts
@@ -11,6 +11,7 @@ export const MetadataFieldOrderByWithRelationInputSchema: z.ZodType<Prisma.Metad
       type: z.lazy(() => SortOrderSchema).optional(),
       target: z.lazy(() => SortOrderSchema).optional(),
       archived: z.lazy(() => SortOrderSchema).optional(),
+      default: z.lazy(() => SortOrderSchema).optional(),
       values: z
         .lazy(() => MetadataOrderByRelationAggregateInputSchema)
         .optional(),

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldScalarFieldEnumSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldScalarFieldEnumSchema.ts
@@ -6,6 +6,7 @@ export const MetadataFieldScalarFieldEnumSchema = z.enum([
   "type",
   "target",
   "archived",
+  "default",
 ]);
 
 export default MetadataFieldScalarFieldEnumSchema;

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldScalarWhereWithAggregatesInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldScalarWhereWithAggregatesInputSchema.ts
@@ -52,6 +52,9 @@ export const MetadataFieldScalarWhereWithAggregatesInputSchema: z.ZodType<Prisma
       archived: z
         .union([z.lazy(() => BoolWithAggregatesFilterSchema), z.boolean()])
         .optional(),
+      default: z
+        .union([z.lazy(() => BoolWithAggregatesFilterSchema), z.boolean()])
+        .optional(),
     })
     .strict();
 

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldSelectSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldSelectSchema.ts
@@ -11,6 +11,7 @@ export const MetadataFieldSelectSchema: z.ZodType<Prisma.MetadataFieldSelect> =
       type: z.boolean().optional(),
       target: z.boolean().optional(),
       archived: z.boolean().optional(),
+      default: z.boolean().optional(),
       values: z
         .union([z.boolean(), z.lazy(() => MetadataFindManyArgsSchema)])
         .optional(),

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldUncheckedCreateInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldUncheckedCreateInputSchema.ts
@@ -12,6 +12,7 @@ export const MetadataFieldUncheckedCreateInputSchema: z.ZodType<Prisma.MetadataF
       type: z.lazy(() => MetadataValueTypeSchema),
       target: z.lazy(() => MetadataTargetTypeSchema),
       archived: z.boolean().optional(),
+      default: z.boolean().optional(),
       values: z
         .lazy(() => MetadataUncheckedCreateNestedManyWithoutFieldInputSchema)
         .optional(),

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldUncheckedCreateWithoutValuesInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldUncheckedCreateWithoutValuesInputSchema.ts
@@ -11,6 +11,7 @@ export const MetadataFieldUncheckedCreateWithoutValuesInputSchema: z.ZodType<Pri
       type: z.lazy(() => MetadataValueTypeSchema),
       target: z.lazy(() => MetadataTargetTypeSchema),
       archived: z.boolean().optional(),
+      default: z.boolean().optional(),
     })
     .strict();
 

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldUncheckedUpdateInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldUncheckedUpdateInputSchema.ts
@@ -42,6 +42,12 @@ export const MetadataFieldUncheckedUpdateInputSchema: z.ZodType<Prisma.MetadataF
           z.lazy(() => BoolFieldUpdateOperationsInputSchema),
         ])
         .optional(),
+      default: z
+        .union([
+          z.boolean(),
+          z.lazy(() => BoolFieldUpdateOperationsInputSchema),
+        ])
+        .optional(),
       values: z
         .lazy(() => MetadataUncheckedUpdateManyWithoutFieldNestedInputSchema)
         .optional(),

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldUncheckedUpdateManyInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldUncheckedUpdateManyInputSchema.ts
@@ -41,6 +41,12 @@ export const MetadataFieldUncheckedUpdateManyInputSchema: z.ZodType<Prisma.Metad
           z.lazy(() => BoolFieldUpdateOperationsInputSchema),
         ])
         .optional(),
+      default: z
+        .union([
+          z.boolean(),
+          z.lazy(() => BoolFieldUpdateOperationsInputSchema),
+        ])
+        .optional(),
     })
     .strict();
 

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldUncheckedUpdateWithoutValuesInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldUncheckedUpdateWithoutValuesInputSchema.ts
@@ -41,6 +41,12 @@ export const MetadataFieldUncheckedUpdateWithoutValuesInputSchema: z.ZodType<Pri
           z.lazy(() => BoolFieldUpdateOperationsInputSchema),
         ])
         .optional(),
+      default: z
+        .union([
+          z.boolean(),
+          z.lazy(() => BoolFieldUpdateOperationsInputSchema),
+        ])
+        .optional(),
     })
     .strict();
 

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldUpdateInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldUpdateInputSchema.ts
@@ -35,6 +35,12 @@ export const MetadataFieldUpdateInputSchema: z.ZodType<Prisma.MetadataFieldUpdat
           z.lazy(() => BoolFieldUpdateOperationsInputSchema),
         ])
         .optional(),
+      default: z
+        .union([
+          z.boolean(),
+          z.lazy(() => BoolFieldUpdateOperationsInputSchema),
+        ])
+        .optional(),
       values: z
         .lazy(() => MetadataUpdateManyWithoutFieldNestedInputSchema)
         .optional(),

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldUpdateManyMutationInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldUpdateManyMutationInputSchema.ts
@@ -34,6 +34,12 @@ export const MetadataFieldUpdateManyMutationInputSchema: z.ZodType<Prisma.Metada
           z.lazy(() => BoolFieldUpdateOperationsInputSchema),
         ])
         .optional(),
+      default: z
+        .union([
+          z.boolean(),
+          z.lazy(() => BoolFieldUpdateOperationsInputSchema),
+        ])
+        .optional(),
     })
     .strict();
 

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldUpdateWithoutValuesInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldUpdateWithoutValuesInputSchema.ts
@@ -34,6 +34,12 @@ export const MetadataFieldUpdateWithoutValuesInputSchema: z.ZodType<Prisma.Metad
           z.lazy(() => BoolFieldUpdateOperationsInputSchema),
         ])
         .optional(),
+      default: z
+        .union([
+          z.boolean(),
+          z.lazy(() => BoolFieldUpdateOperationsInputSchema),
+        ])
+        .optional(),
     })
     .strict();
 

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldWhereInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldWhereInputSchema.ts
@@ -45,6 +45,9 @@ export const MetadataFieldWhereInputSchema: z.ZodType<Prisma.MetadataFieldWhereI
       archived: z
         .union([z.lazy(() => BoolFilterSchema), z.boolean()])
         .optional(),
+      default: z
+        .union([z.lazy(() => BoolFilterSchema), z.boolean()])
+        .optional(),
       values: z.lazy(() => MetadataListRelationFilterSchema).optional(),
     })
     .strict();

--- a/utility/prisma/types/inputTypeSchemas/MetadataFieldWhereUniqueInputSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataFieldWhereUniqueInputSchema.ts
@@ -52,6 +52,9 @@ export const MetadataFieldWhereUniqueInputSchema: z.ZodType<Prisma.MetadataField
           archived: z
             .union([z.lazy(() => BoolFilterSchema), z.boolean()])
             .optional(),
+          default: z
+            .union([z.lazy(() => BoolFilterSchema), z.boolean()])
+            .optional(),
           values: z.lazy(() => MetadataListRelationFilterSchema).optional(),
         })
         .strict(),

--- a/utility/prisma/types/inputTypeSchemas/MetadataTargetTypeSchema.ts
+++ b/utility/prisma/types/inputTypeSchemas/MetadataTargetTypeSchema.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
-export const MetadataTargetTypeSchema = z.enum(["Show", "Rundown"]);
+export const MetadataTargetTypeSchema = z.enum([
+  "Show",
+  "Rundown",
+  "ShowOrRundown",
+]);
 
 export type MetadataTargetTypeType = `${z.infer<
   typeof MetadataTargetTypeSchema

--- a/utility/prisma/types/modelSchema/MetadataFieldSchema.ts
+++ b/utility/prisma/types/modelSchema/MetadataFieldSchema.ts
@@ -12,6 +12,7 @@ export const MetadataFieldSchema = z.object({
   id: z.number().int(),
   name: z.string(),
   archived: z.boolean(),
+  default: z.boolean(),
 });
 
 export type MetadataField = z.infer<typeof MetadataFieldSchema>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6386,6 +6386,7 @@ __metadata:
     tailwind-merge: ^1.14.0
     tailwindcss: ^3.3.3
     tailwindcss-animate: ^1.0.6
+    ts-expect: ^1.3.0
     ts-node: ^10.9.1
     tsx: ^3.12.7
     tus-js-client: ^3.1.0
@@ -15173,6 +15174,13 @@ __metadata:
   peerDependencies:
     typescript: ">=4.2.0"
   checksum: 78794fc7270d295b36c1ac613465b5dc7e7226907a533125b30f177efef9dd630d4e503b00be31b44335eb2ebf9e136ebe97353f8fc5d383885d5fead9d54c09
+  languageName: node
+  linkType: hard
+
+"ts-expect@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "ts-expect@npm:1.3.0"
+  checksum: c007702906354ada640392c26373660a8a034506859b5c084de74376ca2c6fe092c5909235d1bad8ed67423e7ab023dae4dc3032dcdcce70852c0211c5238013
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR introduces a distinction between "default" meta fields, which are always present on their target, and "non-default", which can be added by a button press.

Also a drive-by addition of the `ShowOrRundown` target type, which does exactly what it says on the tin.