### PR TITLE
[BOW-133] Jobrunner refactoring and downloader reliability improvements

### DIFF
--- a/jobrunner/package.json
+++ b/jobrunner/package.json
@@ -37,11 +37,13 @@
     "@types/dotenv-flow": "^3.2.0",
     "@types/lodash": "^4.14.199",
     "dotenv-flow": "^3.2.0",
+    "easydl": "^1.1.1",
     "got": "^13.0.0",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",
     "loglevel-plugin-prefix": "^0.8.4",
     "p-event": "^6.0.0",
+    "s3-readstream": "^2.0.1",
     "ts-expect": "^1.3.0"
   }
 }

--- a/jobrunner/src/invariant.ts
+++ b/jobrunner/src/invariant.ts
@@ -1,0 +1,19 @@
+/**
+ * An invariant is something that should *always* be true. If it's not, it's a bug. Use this function to check,
+ * e.g., that you have a non-null value, or that a value is within a certain range. It means you get more useful error
+ * messages if, for whatever reason, it's not true, rather than a nondescript TypeError. It's particularly useful
+ * together with nullable types when you *know* that the value is non-null, but you (or TypeScript) want to be sure.
+ * @example
+ *   const item = localMedia.find((x) => x.mediaID === info.id);
+ *   invariant(
+ *     item !== undefined,
+ *     "no item (should never happen)",
+ *   );
+ *   // now typescript knows that `item` is not undefined, and you get a better error message if (for whatever reason) it is
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function invariant(cond: any, msg: string): asserts cond {
+  if (!cond) {
+    throw new Error(`Invariant violation: ${msg}`);
+  }
+}

--- a/jobrunner/src/jobs/MediaJobCommon.ts
+++ b/jobrunner/src/jobs/MediaJobCommon.ts
@@ -58,7 +58,7 @@ export abstract class MediaJobCommon extends AbstractJob<
           }),
           s3: this.s3Client,
           maxLength: head.ContentLength!,
-          byteRange: 10 * 1024 * 1024, // 10MB
+          byteRange: 50 * 1024 * 1024, // 50MB
         });
         const output = fs.createWriteStream(filePath);
         await streamPipeline(stream, output);

--- a/jobrunner/src/jobs/MediaJobCommon.ts
+++ b/jobrunner/src/jobs/MediaJobCommon.ts
@@ -10,7 +10,7 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 import invariant from "../invariant";
 import got from "got";
-import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { GetObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
 import { expectNever } from "ts-expect";
 import EasyDL from "easydl";
 import { S3ReadStream } from "s3-readstream";
@@ -45,7 +45,7 @@ export abstract class MediaJobCommon extends AbstractJob<
 
       case MediaFileSourceType.S3: {
         const head = await this.s3Client.send(
-          new GetObjectCommand({
+          new HeadObjectCommand({
             Bucket: process.env.STORAGE_BUCKET,
             Key: params.source,
           }),

--- a/jobrunner/src/jobs/MediaJobCommon.ts
+++ b/jobrunner/src/jobs/MediaJobCommon.ts
@@ -1,0 +1,81 @@
+import {
+  Asset,
+  LoadAssetJob,
+  MediaFileSourceType,
+  ProcessMediaJob,
+  Rundown,
+} from "@bowser/prisma/client";
+import AbstractJob from "./base";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import invariant from "../invariant";
+import got from "got";
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { expectNever } from "ts-expect";
+import EasyDL from "easydl";
+import { S3ReadStream } from "s3-readstream";
+import { pipeline as streamPipeline } from "node:stream/promises";
+import { Upload } from "@aws-sdk/lib-storage";
+
+export abstract class MediaJobCommon extends AbstractJob<
+  ProcessMediaJob | LoadAssetJob
+> {
+  protected async _downloadSourceFile(params: ProcessMediaJob | LoadAssetJob) {
+    const filePath = path.join(this.temporaryDir, "raw");
+    switch (params.sourceType) {
+      case MediaFileSourceType.Tus: {
+        const dl = new EasyDL(
+          process.env.TUS_ENDPOINT + "/" + params.source,
+          filePath,
+        );
+        invariant(await dl.wait(), "download did not succeed");
+
+        await got.delete(process.env.TUS_ENDPOINT + "/" + params.source, {
+          headers: {
+            "Tus-Resumable": "1.0.0",
+          },
+        });
+        break;
+      }
+
+      case MediaFileSourceType.GoogleDrive: {
+        invariant(false, "Google Drive not supported");
+        break;
+      }
+
+      case MediaFileSourceType.S3: {
+        const stream = new S3ReadStream({
+          command: new GetObjectCommand({
+            Bucket: process.env.STORAGE_BUCKET,
+            Key: params.source,
+          }),
+          s3: this.s3Client,
+          maxLength: 50 * 1024 * 1024,
+        });
+        const output = fs.createWriteStream(filePath);
+        await streamPipeline(stream, output);
+        break;
+      }
+
+      default:
+        expectNever(params.sourceType);
+    }
+
+    return filePath;
+  }
+
+  protected async _uploadFileToS3(path: string, s3Path: string) {
+    const stream = fs.createReadStream(path);
+    const upload = new Upload({
+      client: this.s3Client,
+      params: {
+        Bucket: process.env.STORAGE_BUCKET,
+        Key: s3Path,
+        Body: stream,
+      },
+      leavePartsOnError: false,
+    });
+    await upload.done();
+    return s3Path;
+  }
+}

--- a/server/app/shows/[show_id]/ShowItemsList.tsx
+++ b/server/app/shows/[show_id]/ShowItemsList.tsx
@@ -244,7 +244,7 @@ const ContinuityItemRow = forwardRef<
             attachExistingMediaToContinuityItem(item.id, id)
           }
           pastShowsPromise={props.pastShowsPromise}
-          retryProcessing={retryProcessingMedia}
+          retryProcessing={(m) => retryProcessingMedia(m, item.showId)}
           reprocess={reprocessMedia}
         />
       </TableCell>

--- a/server/app/shows/[show_id]/actions.ts
+++ b/server/app/shows/[show_id]/actions.ts
@@ -503,7 +503,7 @@ export async function attachExistingMediaToContinuityItem(
   return { ok: true };
 }
 
-export async function retryProcessingMedia(mediaID: number) {
+export async function retryProcessingMedia(mediaID: number, showID: number) {
   // Reset the job status and re-enqueue it
   const baseJob = await db.$transaction(async ($db) => {
     const baseJob = await $db.baseJob.findUniqueOrThrow({
@@ -534,6 +534,7 @@ export async function retryProcessingMedia(mediaID: number) {
     });
   });
   await dispatchJobForJobrunner(baseJob.id);
+  revalidatePath(`/shows/${showID}`);
   return { ok: true };
 }
 

--- a/server/app/shows/[show_id]/rundown/[rundown_id]/RundownItems.tsx
+++ b/server/app/shows/[show_id]/rundown/[rundown_id]/RundownItems.tsx
@@ -248,7 +248,13 @@ function ItemsTable(props: {
                     attachExistingMediaToRundownItem(item.id, id)
                   }
                   pastShowsPromise={props.pastShowsPromise}
-                  retryProcessing={retryProcessingMedia}
+                  retryProcessing={(m) =>
+                    retryProcessingMedia(
+                      m,
+                      props.rundown.id,
+                      props.rundown.showId,
+                    )
+                  }
                   reprocess={reprocessMedia}
                 />
               )}

--- a/server/app/shows/[show_id]/rundown/[rundown_id]/itemsActions.ts
+++ b/server/app/shows/[show_id]/rundown/[rundown_id]/itemsActions.ts
@@ -404,7 +404,11 @@ export async function attachExistingMediaToRundownItem(
 }
 
 // TODO: duplicated with show actions
-export async function retryProcessingMedia(mediaID: number) {
+export async function retryProcessingMedia(
+  mediaID: number,
+  showID: number,
+  rundownID: number,
+) {
   // Reset the job status and re-enqueue it
   const baseJob = await db.$transaction(async ($db) => {
     const baseJob = await $db.baseJob.findUniqueOrThrow({
@@ -435,6 +439,7 @@ export async function retryProcessingMedia(mediaID: number) {
     });
   });
   await dispatchJobForJobrunner(baseJob.id);
+  revalidatePath(`/shows/${showID}/rundown/${rundownID}`);
   return { ok: true };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6928,6 +6928,7 @@ __metadata:
     "@typescript-eslint/parser": latest
     dotenv: ^16.3.1
     dotenv-flow: ^3.2.0
+    easydl: ^1.1.1
     esbuild: ^0.18.16
     eslint: latest
     glob: ^10.3.3
@@ -6937,6 +6938,7 @@ __metadata:
     loglevel-plugin-prefix: ^0.8.4
     p-event: ^6.0.0
     prettier: ^3.0.3
+    s3-readstream: ^2.0.1
     ts-expect: ^1.3.0
     tsx: ^3.12.7
     typescript: ^5.1.6
@@ -8514,6 +8516,13 @@ __metadata:
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 7d00d7cd8e49b9afa762a813faac332dee781932d6f2c848dc348939c4253f1d4564341b7af1d041853bc3f32c2ef141b58e0a4d9862c17a7f08f68df1e0f1ed
+  languageName: node
+  linkType: hard
+
+"easydl@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "easydl@npm:1.1.1"
+  checksum: f6fe22524e6632a551b961fec96554c34ef3f4aef6c6ac5cde10ee18c3a020dc62aec7114fcff50a303dfacbd9e2b4dfe465099fe1f89e7f2ecc1815c4fc138a
   languageName: node
   linkType: hard
 
@@ -15675,6 +15684,13 @@ __metadata:
   dependencies:
     tslib: ^2.1.0
   checksum: de4b53db1063e618ec2eca0f7965d9137cabe98cf6be9272efe6c86b47c17b987383df8574861bcced18ebd590764125a901d5506082be84a8b8e364bf05f119
+  languageName: node
+  linkType: hard
+
+"s3-readstream@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "s3-readstream@npm:2.0.1"
+  checksum: 19b324c5100e9e471ca52abd0dc4e500fb27bf643c66cb2833a43dd32ea462dcf12c42de956c89e28c71f4c03ebe83a12b724b2b938acb87ef639b607dc856a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Refactor the common elements of LoadAssetJob and ProcessMediaJob (file downloads and uploads) into MediaJobCommon.

In there, switch to using `easydl`/`s3-readstream` rather than `got`/`s3-client` for Tus/S3 downloads respectively, as they handle chunking and retries.