### PR TITLE
Implement auto-updating on show and rundown pages

### DIFF
--- a/server/app/shows/[show_id]/actions.ts
+++ b/server/app/shows/[show_id]/actions.ts
@@ -19,6 +19,23 @@ import { escapeRegExp } from "lodash";
 import { dispatchJobForJobrunner } from "@/lib/jobs";
 import invariant from "@/lib/invariant";
 
+export async function revalidateIfChanged(showID: number, version: number) {
+  const show = await db.show.findUnique({
+    where: {
+      id: showID,
+    },
+    select: {
+      version: true,
+    },
+  });
+  if (!show) {
+    notFound();
+  }
+  if (show.version !== version) {
+    revalidatePath(`/shows/${showID}`);
+  }
+}
+
 export async function addItem(
   showID: number,
   type: "rundown" | "continuity_item",

--- a/server/app/shows/[show_id]/page.tsx
+++ b/server/app/shows/[show_id]/page.tsx
@@ -7,7 +7,7 @@ import { getTusEndpoint } from "@/lib/tus";
 import { DateTime } from "@/components/DateTIme";
 import { MetadataFields } from "@/components/Metadata";
 import { MetadataTargetType, Permission } from "@bowser/prisma/client";
-import { addMeta, setMetaValue } from "./actions";
+import { addMeta, revalidateIfChanged, setMetaValue } from "./actions";
 import { cache } from "react";
 import { PastShowsMedia } from "@/components/MediaSelection";
 import { requirePermission } from "@/lib/auth";
@@ -15,6 +15,7 @@ import { FlagGate } from "@/components/FeatureFlags";
 import { PermissionGate } from "@/components/PermissionGate";
 import Button from "@bowser/components/button";
 import Link from "next/link";
+import { Poll } from "../../../components/Poll";
 
 // TODO: duplicated in rundown/id/page.ts
 const pastShowsPromise = cache(
@@ -134,6 +135,7 @@ export default async function ShowPage(props: { params: { show_id: string } }) {
           pastShowsPromise={pastShowsPromise()}
         />
       </TusEndpointProvider>
+      <Poll action={revalidateIfChanged} params={[show.id, show.version]} />
     </>
   );
 }

--- a/server/app/shows/[show_id]/rundown/[rundown_id]/RundownItems.tsx
+++ b/server/app/shows/[show_id]/rundown/[rundown_id]/RundownItems.tsx
@@ -195,27 +195,6 @@ function ItemsTable(props: {
     [props.rundown.id, doOptimisticMove],
   );
 
-  // Periodically refresh if any items are pending
-  const intervalRef = useRef<NodeJS.Timer | null>(null);
-  useEffect(() => {
-    const anyPending = props.rundown.items.some(
-      (x) =>
-        x.media?.state === MediaState.Pending ||
-        x.media?.state === MediaState.Processing,
-    );
-    if (!anyPending) {
-      return;
-    }
-    intervalRef.current = setInterval(() => {
-      router.refresh();
-    }, 2500);
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-      }
-    };
-  }, [props.rundown.items, router]);
-
   const items: ReactNode[] = [];
   let runningDurationSeconds = 0;
   for (let idx = 0; idx < optimisticItems.length; idx++) {

--- a/server/app/shows/[show_id]/rundown/[rundown_id]/actions.ts
+++ b/server/app/shows/[show_id]/rundown/[rundown_id]/actions.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { revalidatePath } from "next/cache";
+import { notFound } from "next/navigation";
+
+export async function revalidateIfChanged(rundownID: number, version: number) {
+  const rundown = await db.rundown.findUnique({
+    where: { id: rundownID },
+    select: {
+      show: {
+        select: { version: true, id: true },
+      },
+    },
+  });
+  if (!rundown) {
+    notFound();
+  }
+  if (rundown.show.version !== version) {
+    revalidatePath(`/shows/${rundown.show.id}/rundown/${rundownID}`);
+  }
+}

--- a/server/app/shows/[show_id]/rundown/[rundown_id]/page.tsx
+++ b/server/app/shows/[show_id]/rundown/[rundown_id]/page.tsx
@@ -11,6 +11,8 @@ import { MetadataTargetType } from "@bowser/prisma/client";
 import { MetadataFields } from "@/components/Metadata";
 import { addMeta, setMetaValue } from "./metaActions";
 import { PastShowsMedia } from "@/components/MediaSelection";
+import { Poll } from "@/components/Poll";
+import { revalidateIfChanged } from "./actions";
 
 const pastShowsPromise = cache(
   () =>
@@ -135,6 +137,13 @@ export default async function RundownPage(props: {
     where: {
       id: parseInt(props.params.rundown_id, 10),
     },
+    include: {
+      show: {
+        select: {
+          version: true,
+        },
+      },
+    },
   });
   if (!rundown) {
     notFound();
@@ -161,6 +170,10 @@ export default async function RundownPage(props: {
           </Suspense>
         </TusEndpointProvider>
       </div>
+      <Poll
+        action={revalidateIfChanged}
+        params={[rundown.id, rundown.show.version]}
+      />
     </div>
   );
 }

--- a/server/components/Poll.tsx
+++ b/server/components/Poll.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect, useTransition } from "react";
+
+/**
+ * Implements the "polling server action" pattern: https://twitter.com/sebmarkbage/status/1667217918105403416
+ *
+ * Pass a Server Action that calls revalidatePath(currentPath) if the data displayed by this page has changed.
+ */
+export function Poll<TParams extends unknown[] = []>(props: {
+  params: TParams;
+  action: (...params: TParams) => Promise<void>;
+  interval?: number;
+}) {
+  const [_, startTransition] = useTransition();
+  const { params, action, interval = 5000 } = props;
+  useEffect(() => {
+    function poll() {
+      startTransition(async () => {
+        await action(...params);
+        setTimeout(poll, interval);
+      });
+    }
+    const id = setTimeout(poll, interval);
+    return () => {
+      clearTimeout(id);
+    };
+  }, [params, action, interval]);
+  return null;
+}

--- a/server/components/Poll.tsx
+++ b/server/components/Poll.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useTransition } from "react";
+import { useEffect, useRef, useTransition } from "react";
 
 /**
  * Implements the "polling server action" pattern: https://twitter.com/sebmarkbage/status/1667217918105403416
@@ -14,16 +14,19 @@ export function Poll<TParams extends unknown[] = []>(props: {
 }) {
   const [_, startTransition] = useTransition();
   const { params, action, interval = 5000 } = props;
+  const idRef = useRef<number | NodeJS.Timeout | null>(null);
   useEffect(() => {
     function poll() {
       startTransition(async () => {
         await action(...params);
-        setTimeout(poll, interval);
+        idRef.current = setTimeout(poll, interval);
       });
     }
-    const id = setTimeout(poll, interval);
+    idRef.current = setTimeout(poll, interval);
     return () => {
-      clearTimeout(id);
+      if (idRef.current) {
+        clearTimeout(idRef.current);
+      }
     };
   }, [params, action, interval]);
   return null;


### PR DESCRIPTION
Do a little bit of RSC-sorcery to periodically check if the show has changed, and update the page if so:
![polling](https://github.com/ystv/bowser/assets/2904440/0b132437-6e30-4b73-a7a6-7fd301a1e71c)
This basically implements (albeit very slow) collaborative editing for rundowns.


see: https://twitter.com/sebmarkbage/status/1667217918105403416

This is fairly efficient thanks to the show versioning mechanism, as getting the version of a show is one DB query fetching one column (and we could optimise it even further if we wanted/needed to).